### PR TITLE
Remove .git from repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # github-release-notes
 
-`ruby releasenotes.rb generate --repo <path the local repo (.git file)> --from  <last git tag> --to <current git tag> --github https://github.com/jetpackworkflow/checklistpro.git`
+`ruby releasenotes.rb generate --repo <path the local repo (.git file)> --from  <last git tag> --to <current git tag> --github https://github.com/jetpackworkflow/checklistpro`


### PR DESCRIPTION
Removes ".git" from the repository suggested link to avoid creating wrong links for PRs, Issues, etc...
